### PR TITLE
Fix mod menu dependency version, fix method name

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -15,5 +15,5 @@ org.gradle.jvmargs=-Xmx1G
 # Dependencies
 	# currently not on the main fabric site, check on the maven: https://maven.fabricmc.net/net/fabricmc/fabric-api/fabric-api
     fabric_version=0.75.3+1.19.4
-    modmenu_version=6.1.0
+    modmenu_version=6.1.0-rc.4
     sodium_version=mc1.19.4-0.4.10

--- a/src/main/java/net/boostedbrightness/ui/ModMenuIntegration.java
+++ b/src/main/java/net/boostedbrightness/ui/ModMenuIntegration.java
@@ -38,7 +38,7 @@ public class ModMenuIntegration implements ModMenuApi {
         public void render(MatrixStack matrices, int mouseX, int mouseY, float delta) {
             this.renderBackground(matrices);
             this.list.render(matrices, mouseX, mouseY, delta);
-            drawCenteredText(matrices, this.textRenderer, this.title, this.width / 2, 5, 0xffffff);
+            drawCenteredTextWithShadow(matrices, this.textRenderer, this.title, this.width / 2, 5, 0xffffff);
             super.render(matrices, mouseX, mouseY, delta);
         }
     


### PR DESCRIPTION
`6.1.0` is not a valid version for `modmenu`, this has been updated.

It seems one of the method's name has changed in `modmenu` so that has been updated so it will compile now.